### PR TITLE
Gérer les quizs avec plusieurs auteurs

### DIFF
--- a/frontend/src/components/QuestionFilter.vue
+++ b/frontend/src/components/QuestionFilter.vue
@@ -39,6 +39,7 @@
           <p v-if="categories && objectType =='question'">
             <span>{{ $t('messages.category') }}{{ $t('words.semiColon') }}&nbsp;</span>
             <select v-model="tempQuestionFilters['category']">
+              <option></option>
               <option v-for="(option, i) in tags" :key="i" :value="option.name">
                   {{ option.name }} ({{ option[objectType === 'question' ? 'question_count' : 'quiz_count'] }})
                 </option>
@@ -47,6 +48,7 @@
           <p v-if="tags">
             <span>{{ $t('messages.tag') }}{{ $t('words.semiColon') }}&nbsp;</span>
             <select v-model="tempQuestionFilters['tag']">
+              <option></option>
               <option v-for="(option, i) in tags" :key="i" :value="option.name">
                   {{ option.name }} ({{ option[objectType === 'question' ? 'question_count' : 'quiz_count'] }})
                 </option>
@@ -55,6 +57,7 @@
           <p v-if="authors">
             <span>{{ $t('messages.author') }}{{ $t('words.semiColon') }}&nbsp;</span>
             <select v-model="tempQuestionFilters['author']">
+              <option></option>
               <option v-for="(option, i) in authors" :key="i" :value="option.full_name">
                 {{ option.full_name }} ({{ option[objectType === 'question' ? 'question_count' : 'quiz_count'] }})
               </option>
@@ -63,6 +66,7 @@
           <p v-if="difficultyLevels && objectType =='question'">
             <span>{{ $t('messages.difficulty') }}{{ $t('words.semiColon') }}&nbsp;</span>
             <select v-model="tempQuestionFilters['difficulty']">
+              <option></option>
               <option v-for="(option, i) in difficultyLevels" :key="i" :value="option.name">
                 {{ option.name }} ({{ option[objectType === 'question' ? 'question_count' : 'quiz_count'] }})
               </option>

--- a/frontend/src/components/QuestionFilter.vue
+++ b/frontend/src/components/QuestionFilter.vue
@@ -55,8 +55,8 @@
           <p v-if="authors">
             <span>{{ $t('messages.author') }}{{ $t('words.semiColon') }}&nbsp;</span>
             <select v-model="tempQuestionFilters['author']">
-              <option v-for="(option, i) in authors" :key="i" :value="option.id">
-                {{ option.first_name + ' ' + option.last_name }} ({{ option[objectType === 'question' ? 'question_count' : 'quiz_count'] }})
+              <option v-for="(option, i) in authors" :key="i" :value="option.full_name">
+                {{ option.full_name }} ({{ option[objectType === 'question' ? 'question_count' : 'quiz_count'] }})
               </option>
             </select>
           </p>

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -189,7 +189,13 @@ const store = new Vuex.Store({
      * Pre-processing ? None
      */
     GET_AUTHOR_LIST_FROM_LOCAL_YAML: ({ commit }) => {
-      commit('SET_AUTHOR_LIST', { list: authorsYamlData });
+      const authors = authorsYamlData;
+      authors.map((a) => {
+        const authorFullName = `${a.first_name} ${a.last_name}`;
+        Object.assign(a, { full_name: authorFullName });
+        return a;
+      });
+      commit('SET_AUTHOR_LIST', { list: authors });
     },
     /**
      * Get difficulty-levels
@@ -345,7 +351,7 @@ const store = new Vuex.Store({
     getQuestionsValidatedByFilter: (state) => (filter) => state.questionsValidated
       .filter((q) => (filter.category ? (q.category.name === filter.category) : true))
       .filter((q) => (filter.tag ? q.tags.map((qt) => qt.name).includes(filter.tag) : true))
-      .filter((q) => (filter.author ? (q.author.id === filter.author) : true))
+      .filter((q) => (filter.author ? (q.author.full_name === filter.author) : true))
       .filter((q) => (filter.difficulty ? (q.difficulty === parseInt(filter.difficulty, 10)) : true)),
     getCurrentQuestionIndex: (state) => (currentQuestionId) => state.questionsDisplayed.findIndex((q) => q.id === currentQuestionId),
     getNextQuestionByFilter: (state) => (currentQuestionId) => {
@@ -358,7 +364,7 @@ const store = new Vuex.Store({
     getQuizsByIdList: (state) => (quizIdList) => state.quizs.filter((q) => quizIdList.includes(q.id)),
     getQuizsPublishedByFilter: (state) => (filter) => state.quizsPublished
       .filter((q) => (filter.tag ? q.tags.map((qt) => qt.name).includes(filter.tag) : true))
-      .filter((q) => (filter.author ? q.authors.map((qa) => qa.id).includes(filter.author) : true))
+      .filter((q) => (filter.author ? q.authors.map((qa) => qa.full_name).includes(filter.author) : true))
       .sort((a, b) => ((filter.sort === 'date_old') ? (a.created.localeCompare(b.created)) : (b.id - a.id))),
     getQuizRelationshipsById: (state) => (quizId) => state.quizRelationships.filter((qr) => (qr.from_quiz === quizId) || (qr.to_quiz === quizId)),
     getQuizStatsById: (state) => (quizId) => state.quizStats.find((q) => (q.quiz_id === quizId)),

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -135,10 +135,10 @@ const store = new Vuex.Store({
         const quizQuestions = getters.getQuestionsByIdList(quizQuestionsIdList);
         quizQuestions.sort((a, b) => quizQuestionsIdList.indexOf(a.id) - quizQuestionsIdList.indexOf(b.id));
         // get quiz author & tags
-        const quizAuthor = getters.getUserById(q.author);
+        const quizAuthors = getters.getUsersByIdList(q.authors);
         const quizTags = getters.getTagsByIdList(q.tags);
         // assign
-        Object.assign(q, { questions: quizQuestions }, { author: quizAuthor }, { tags: quizTags });
+        Object.assign(q, { questions: quizQuestions }, { authors: quizAuthors }, { tags: quizTags });
         return q;
       });
       const quizsPublished = quizs.filter((q) => q.language === state.locale.value).filter((el) => el.publish === true);
@@ -330,7 +330,8 @@ const store = new Vuex.Store({
     },
   },
   getters: {
-    getUserById: (state) => (userId) => state.authors.find((c) => (c.id === ((userId && typeof userId === 'object') ? userId.id : userId))),
+    getUserById: (state) => (userId) => state.authors.find((u) => (u.id === ((userId && typeof userId === 'object') ? userId.id : userId))),
+    getUsersByIdList: (state) => (userIdList) => state.authors.filter((u) => ((userIdList && userIdList.length && typeof userIdList[0] === 'object') ? userIdList.map((user) => user.id).includes(u.id) : userIdList.includes(u.id))),
     getCategoryById: (state) => (categoryId) => state.categories.find((c) => (c.id === ((categoryId && typeof categoryId === 'object') ? categoryId.id : categoryId))),
     getTagById: (state) => (tagId) => state.tags.find((t) => (t.id === ((tagId && typeof tagId === 'object') ? tagId.id : tagId))),
     getTagsByIdList: (state) => (tagIdList) => state.tags.filter((t) => ((tagIdList && tagIdList.length && typeof tagIdList[0] === 'object') ? tagIdList.map((tag) => tag.id).includes(t.id) : tagIdList.includes(t.id))),
@@ -341,7 +342,8 @@ const store = new Vuex.Store({
     getQuestionsByCategoryName: (state) => (categoryName) => state.questions.filter((q) => (q.category.name === categoryName)),
     getQuestionsByTagName: (state) => (tagName) => state.questions.filter((q) => q.tags.map((qt) => qt.name).includes(tagName)),
     getQuestionsByAuthorName: (state) => (authorName) => state.questions.filter((q) => q.author === authorName),
-    getQuestionsValidatedByFilter: (state) => (filter) => state.questionsValidated.filter((q) => (filter.category ? (q.category.name === filter.category) : true))
+    getQuestionsValidatedByFilter: (state) => (filter) => state.questionsValidated
+      .filter((q) => (filter.category ? (q.category.name === filter.category) : true))
       .filter((q) => (filter.tag ? q.tags.map((qt) => qt.name).includes(filter.tag) : true))
       .filter((q) => (filter.author ? (q.author.id === filter.author) : true))
       .filter((q) => (filter.difficulty ? (q.difficulty === parseInt(filter.difficulty, 10)) : true)),
@@ -354,8 +356,9 @@ const store = new Vuex.Store({
     getQuizById: (state) => (quizId) => state.quizs.find((q) => (q.id === quizId)),
     getQuizBySlug: (state) => (quizId) => state.quizs.find((q) => (q.slug === quizId)),
     getQuizsByIdList: (state) => (quizIdList) => state.quizs.filter((q) => quizIdList.includes(q.id)),
-    getQuizsPublishedByFilter: (state) => (filter) => state.quizsPublished.filter((q) => (filter.tag ? q.tags.map((qt) => qt.name).includes(filter.tag) : true))
-      .filter((q) => (filter.author ? (q.author.id === filter.author) : true))
+    getQuizsPublishedByFilter: (state) => (filter) => state.quizsPublished
+      .filter((q) => (filter.tag ? q.tags.map((qt) => qt.name).includes(filter.tag) : true))
+      .filter((q) => (filter.author ? q.authors.map((qa) => qa.id).includes(filter.author) : true))
       .sort((a, b) => ((filter.sort === 'date_old') ? (a.created.localeCompare(b.created)) : (b.id - a.id))),
     getQuizRelationshipsById: (state) => (quizId) => state.quizRelationships.filter((qr) => (qr.from_quiz === quizId) || (qr.to_quiz === quizId)),
     getQuizStatsById: (state) => (quizId) => state.quizStats.find((q) => (q.quiz_id === quizId)),

--- a/frontend/src/views/QuizDetailPage.vue
+++ b/frontend/src/views/QuizDetailPage.vue
@@ -43,7 +43,7 @@
             <div class="col" title="Auteur du quiz">
               📝&nbsp;{{ $t('messages.author') }}<span v-if="quiz.authors.length > 1">s</span>
               <span v-for="(author, index) in quiz.authors" :key="author.id" class="label label-hidden">
-                <strong>{{ author.first_name }} {{ author.last_name }}{{ (index < quiz.authors.length - 1) ? ',' : '' }}</strong>
+                <strong>{{ author.full_name }}{{ (index < quiz.authors.length - 1) ? ',' : '' }}</strong>
               </span>
             </div>
             <!-- <span title="Date de création du quiz">📊&nbsp;Crée le:&nbsp;{{ new Date(quiz.created).toLocaleString() }}</span> -->

--- a/frontend/src/views/QuizDetailPage.vue
+++ b/frontend/src/views/QuizDetailPage.vue
@@ -41,7 +41,10 @@
               🏆&nbsp;{{ $t('messages.difficulty') }}<span class="label label-hidden"><strong>{{ quiz.difficulty_average | round(1) }} / 4</strong></span>
             </div> -->
             <div class="col" title="Auteur du quiz">
-              📝&nbsp;{{ $t('messages.author') }}<span class="label label-hidden"><strong>{{ quiz.author.first_name }} {{ quiz.author.last_name }}</strong></span>
+              📝&nbsp;{{ $t('messages.author') }}<span v-if="quiz.authors.length > 1">s</span>
+              <span v-for="(author, index) in quiz.authors" :key="author.id" class="label label-hidden">
+                <strong>{{ author.first_name }} {{ author.last_name }}{{ (index < quiz.authors.length - 1) ? ',' : '' }}</strong>
+              </span>
             </div>
             <!-- <span title="Date de création du quiz">📊&nbsp;Crée le:&nbsp;{{ new Date(quiz.created).toLocaleString() }}</span> -->
             <div v-if="quiz.tags && quiz.tags.length > 0" class="col small d-none d-sm-block" title="Mot(s) clé(s) du quiz">

--- a/frontend/src/views/StatsPage.vue
+++ b/frontend/src/views/StatsPage.vue
@@ -54,8 +54,8 @@
     <h4>✍️&nbsp;{{ $t('messages.authors') }}</h4>
     <p>
       <span v-for="author in quizAuthors" :key="author.id">
-        <router-link class="no-decoration" :to="{ name: 'quiz-list', query: { author: author.id } }">
-          <FilterLabel :key="author.id" filterType="author" v-bind:filterValue="author.first_name + ' ' + author.last_name" v-bind:filterCount="author.quiz_count" />
+        <router-link class="no-decoration" :to="{ name: 'quiz-list', query: { author: author.full_name } }">
+          <FilterLabel :key="author.id" filterType="author" v-bind:filterValue="author.full_name" v-bind:filterCount="author.quiz_count" />
         </router-link>
       </span>
     </p>
@@ -107,8 +107,8 @@
     <h4>✍️&nbsp;{{ $t('messages.authors') }}</h4>
     <p>
       <span v-for="author in questionAuthors" :key="author.id">
-        <router-link class="no-decoration" :to="{ name: 'question-list', query: { author: author.id } }">
-          <FilterLabel :key="author.id" filterType="author" v-bind:filterValue="author.first_name + ' ' + author.last_name" v-bind:filterCount="author.question_count" />
+        <router-link class="no-decoration" :to="{ name: 'question-list', query: { author: author.full_name } }">
+          <FilterLabel :key="author.id" filterType="author" v-bind:filterValue="author.full_name" v-bind:filterCount="author.question_count" />
         </router-link>
       </span>
     </p>


### PR DESCRIPTION
Dans le backend, il est maintenant possible d'avoir des quizs avec plusieurs auteurs.
Cela change le format de donnée reçu : une liste de FK au lieu d'une simple FK.
cf https://github.com/quiz-anthropocene/admin-backend/issues/1886

Modifications dans le `store.js`, l'affichage, et les filtres.