### PR TITLE
Récupérer le glossaire, les catégories et les tags via l'API

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -143,7 +143,7 @@ export default {
       this.$store.dispatch('GET_QUIZ_LIST_FROM_LOCAL_YAML');
       this.$store.dispatch('UPDATE_QUIZ_FILTERS', {});
       // needed for both glossary page & abbr filter
-      this.$store.dispatch('GET_RESSOURCES_GLOSSAIRE_LIST_FROM_LOCAL_YAML');
+      this.$store.dispatch('GET_RESSOURCES_GLOSSAIRE_LIST_FROM_API');
     },
     dismissAlert() {
       this.$store.dispatch('RESET_LOADING_STATUS');

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -139,7 +139,7 @@ export default {
       this.$store.dispatch('GET_AUTHOR_LIST_FROM_LOCAL_YAML');
       Promise.all([
         this.$store.dispatch('GET_CATEGORY_LIST_FROM_API'),
-        this.$store.dispatch('GET_TAG_LIST_FROM_LOCAL_YAML'),
+        this.$store.dispatch('GET_TAG_LIST_FROM_API'),
       ]).then(() => {
         this.$store.dispatch('GET_QUESTION_LIST_FROM_LOCAL_YAML');
       }).then(() => {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -137,10 +137,14 @@ export default {
       this.$store.dispatch('GET_DIFFICULTY_LEVEL_LIST_FROM_LOCAL_YAML');
       this.$store.dispatch('GET_LANGUAGE_LIST_FROM_LOCAL_YAML');
       this.$store.dispatch('GET_AUTHOR_LIST_FROM_LOCAL_YAML');
-      this.$store.dispatch('GET_CATEGORY_LIST_FROM_LOCAL_YAML');
-      this.$store.dispatch('GET_TAG_LIST_FROM_LOCAL_YAML');
-      this.$store.dispatch('GET_QUESTION_LIST_FROM_LOCAL_YAML');
-      this.$store.dispatch('GET_QUIZ_LIST_FROM_LOCAL_YAML');
+      Promise.all([
+        this.$store.dispatch('GET_CATEGORY_LIST_FROM_API'),
+        this.$store.dispatch('GET_TAG_LIST_FROM_LOCAL_YAML'),
+      ]).then(() => {
+        this.$store.dispatch('GET_QUESTION_LIST_FROM_LOCAL_YAML');
+      }).then(() => {
+        this.$store.dispatch('GET_QUIZ_LIST_FROM_LOCAL_YAML');
+      });
       this.$store.dispatch('UPDATE_QUIZ_FILTERS', {});
       // needed for both glossary page & abbr filter
       this.$store.dispatch('GET_RESSOURCES_GLOSSAIRE_LIST_FROM_API');

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -138,7 +138,9 @@ export default {
       this.$store.dispatch('GET_LANGUAGE_LIST_FROM_LOCAL_YAML');
       this.$store.dispatch('GET_AUTHOR_LIST_FROM_LOCAL_YAML');
       Promise.all([
+        // this.$store.dispatch('GET_CATEGORY_LIST_FROM_LOCAL_YAML'),
         this.$store.dispatch('GET_CATEGORY_LIST_FROM_API'),
+        // this.$store.dispatch('GET_TAG_LIST_FROM_LOCAL_YAML'),
         this.$store.dispatch('GET_TAG_LIST_FROM_API'),
       ]).then(() => {
         this.$store.dispatch('GET_QUESTION_LIST_FROM_LOCAL_YAML');
@@ -146,7 +148,9 @@ export default {
         this.$store.dispatch('GET_QUIZ_LIST_FROM_LOCAL_YAML');
       });
       this.$store.dispatch('UPDATE_QUIZ_FILTERS', {});
+
       // needed for both glossary page & abbr filter
+      // this.$store.dispatch('GET_RESSOURCES_GLOSSAIRE_LIST_FROM_LOCAL_YAML');
       this.$store.dispatch('GET_RESSOURCES_GLOSSAIRE_LIST_FROM_API');
     },
     dismissAlert() {

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -225,6 +225,23 @@ const store = new Vuex.Store({
     GET_RESSOURCES_GLOSSAIRE_LIST_FROM_LOCAL_YAML: ({ commit }) => {
       commit('SET_RESSOURCES_GLOSSAIRE_LIST', { list: ressourcesGlossaireYamlData });
     },
+    GET_RESSOURCES_GLOSSAIRE_LIST_FROM_API: ({ commit }) => {
+      fetch(`${process.env.VUE_APP_API_ENDPOINT}/glossary/`, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+      })
+        .then((response) => response.json())
+        // eslint-disable-next-line
+        .then(data => {
+          commit('SET_RESSOURCES_GLOSSAIRE_LIST', { list: data.results });
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    },
     GET_RESSOURCES_SOUTIENS_LIST_FROM_LOCAL_YAML: ({ commit }) => {
       commit('SET_RESSOURCES_SOUTIENS_LIST', { list: ressourcesSoutiensYamlData });
     },

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -10,14 +10,11 @@ import statsYamlData from '../../data/stats.yaml';
 import languagesYamlData from '../../data/languages.yaml';
 import authorsYamlData from '../../data/authors.yaml';
 import difficultyLevelsYamlData from '../../data/difficulty-levels.yaml';
-import categoriesYamlData from '../../data/categories.yaml';
-import tagsYamlData from '../../data/tags.yaml';
 import questionsYamlData from '../../data/questions.yaml';
 import quizsYamlData from '../../data/quizs.yaml';
 import quizQuestionsYamlData from '../../data/quiz-questions.yaml';
 import quizRelationshipsYamlData from '../../data/quiz-relationships.yaml';
 import quizStatsYamlData from '../../data/quiz-stats.yaml';
-import ressourcesGlossaireYamlData from '../../data/ressources-glossaire.yaml';
 import ressourcesSoutiensYamlData from '../../data/ressources-soutiens.yaml';
 import ressourcesAutresAppsYamlData from '../../data/ressources-autres-apps.yaml';
 
@@ -203,7 +200,9 @@ const store = new Vuex.Store({
      * Pre-processing ? None
      */
     GET_CATEGORY_LIST_FROM_LOCAL_YAML: ({ commit }) => {
-      commit('SET_CATEGORY_LIST', { list: categoriesYamlData });
+      import('../../data/categories.yaml').then((module) => {
+        commit('SET_CATEGORY_LIST', { list: module.default });
+      });
     },
     GET_CATEGORY_LIST_FROM_API: ({ commit }) => {
       return fetch(`${process.env.VUE_APP_API_ENDPOINT}/categories/`, {
@@ -227,7 +226,9 @@ const store = new Vuex.Store({
      * Pre-processing ? None
      */
     GET_TAG_LIST_FROM_LOCAL_YAML: ({ commit }) => {
-      return commit('SET_TAG_LIST', { list: tagsYamlData });
+      import('../../data/tags.yaml').then((module) => {
+        commit('SET_TAG_LIST', { list: module.default });
+      });
     },
     GET_TAG_LIST_FROM_API: ({ commit }) => {
       return fetch(`${process.env.VUE_APP_API_ENDPOINT}/tags/?limit=10000`, {
@@ -251,7 +252,9 @@ const store = new Vuex.Store({
      * Pre-processing ? for soutiens, append quiz tag or question author
      */
     GET_RESSOURCES_GLOSSAIRE_LIST_FROM_LOCAL_YAML: ({ commit }) => {
-      commit('SET_RESSOURCES_GLOSSAIRE_LIST', { list: ressourcesGlossaireYamlData });
+      import('../../data/ressources-glossaire.yaml').then((module) => {
+        commit('SET_RESSOURCES_GLOSSAIRE_LIST', { list: module.default });
+      });
     },
     GET_RESSOURCES_GLOSSAIRE_LIST_FROM_API: ({ commit }) => {
       fetch(`${process.env.VUE_APP_API_ENDPOINT}/glossary/`, {

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -229,6 +229,23 @@ const store = new Vuex.Store({
     GET_TAG_LIST_FROM_LOCAL_YAML: ({ commit }) => {
       return commit('SET_TAG_LIST', { list: tagsYamlData });
     },
+    GET_TAG_LIST_FROM_API: ({ commit }) => {
+      return fetch(`${process.env.VUE_APP_API_ENDPOINT}/tags/?limit=10000`, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+      })
+        .then((response) => response.json())
+        // eslint-disable-next-line
+        .then(data => {
+          commit('SET_TAG_LIST', { list: data.results });
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    },
     /**
      * Get ressources: glossaire, soutiens, autres apps
      * Pre-processing ? for soutiens, append quiz tag or question author


### PR DESCRIPTION
Issue https://github.com/quiz-anthropocene/public-frontend/issues/476

- récupérer la liste de glossaire en faisant un appel API (au lieu de parser le fichier `data/ressources-glossaire.yaml`
- de même pour la liste des catégories
- de même pour la liste des tags