### PR TITLE
l10n: add Italian & Spanish

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -15,6 +15,8 @@ export default {
     { code: 'fr', value: 'FRENCH', name: 'Français' },
     { code: 'en', value: 'ENGLISH', name: 'English' },
     { code: 'de', value: 'GERMAN', name: 'Deutsch' },
+    { code: 'it', value: 'ITALIAN', name: 'Italiano' },
+    { code: 'es', value: 'SPANISH', name: 'Español' },
   ],
   // DEFAULT_BACKGROUND_IMAGE_NAME: 'https://quizanthropocene.fr/showyourstripes_globe_1850-2019.png'
 };


### PR DESCRIPTION
We have these languages in Crowdin. But not yet in the UI dropdown