### PR TITLE
chore: Update dependencies (chromedriver)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "@vue/cli-service": "^5.0.0",
     "@vue/eslint-config-airbnb": "^7.0.0",
     "babel-eslint": "^10.1.0",
-    "chromedriver": "129",
+    "chromedriver": "131",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-vue": "^9.6.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2843,10 +2843,10 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@129:
-  version "129.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-129.0.0.tgz#28d7ede5ab372b868ac0db5efff7036646b4d603"
-  integrity sha512-B1ccqD6hDjNrw94FeqdynIotn1ZV/TnFrkRz2Rync2kzSnq6D6IrSkN1w5Pnuvnc98QhN2xujxDXxkqEqy/PWg==
+chromedriver@131:
+  version "131.0.2"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-131.0.2.tgz#fab55b3935a56884ab4a7411bb59286e8ba89cd7"
+  integrity sha512-Z3oZmleJP3UEBKCz7XLZoZSbYRnApFmUL4GGmLHxw/NJqcZpEnCNFlwdVKuRlntCPxgdfvYInQCPmZxXyrGE+w==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
     axios "^1.7.4"


### PR DESCRIPTION
Update `chromedriver` from v129 to v131